### PR TITLE
added requirements file for easier kickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,13 @@ We finetune a decoder-only model (gemma-2b or Llama3.1) in a multi-task setting.
 
 ## Requirements
 
-You should install the following requirements. All of them can be installed with `pip install [requirement]`
+Install the requirements.
 
-
-```
-torch
-transformers
-accelerate
-deepspeed
-outlines
-pydantic
-bitsandbytes
-jinja2
+```bash
+pip install -r requirements.txt
 ```
 
-
-You should unzip the `.zip` file in [data/](data/)
+You should also unzip the `.zip` file in [data/](data/)
 
 ## Run Evaluation/Inference
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+torch
+transformers
+accelerate
+deepspeed
+outlines
+pydantic
+bitsandbytes
+jinja2


### PR DESCRIPTION
This PR adds a requirements.txt file to make easier the kickstart. Just `pip install -r requirements` and no need to install each package manually.

Preferrably, versions should be pinned to the specific version used, but I will leave this up to the mantainers.